### PR TITLE
fix(ci): add pnpm.onlyBuiltDependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,5 +203,10 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@libar-dev/modular-claude-md"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

The `.npmrc` file with `onlyBuiltDependencies` doesn't seem to be read properly during pnpm's git dependency preparation phase.

## Solution

Add the setting to `package.json` under the `pnpm` field, which should be more reliable.

This fixes `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` when this package is installed as a git dependency and needs to install `modular-claude-md`.

Related: #11